### PR TITLE
商品購入機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,5 @@ end
 gem 'devise'
 gem 'pry-rails'
 gem 'active_hash'
+gem 'payjp'
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -111,6 +113,14 @@ GEM
       romaji
     globalid (1.1.0)
       activesupport (>= 5.0)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.1)
@@ -135,9 +145,13 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.5.0)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0808)
     mini_mime (1.1.2)
     minitest (5.19.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.3.7)
       date
@@ -148,6 +162,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
@@ -156,6 +171,8 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.5.3)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -202,9 +219,16 @@ GEM
     regexp_parser (2.8.1)
     reline (0.3.7)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.6)
     romaji (0.2.4)
       rake (>= 0.8.0)
@@ -261,6 +285,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -293,9 +320,11 @@ DEPENDENCIES
   factory_bot_rails
   faker
   gimei
+  gon
   importmap-rails
   jbuilder
   mysql2 (~> 0.5)
+  payjp
   pg
   pry-rails
   puma (~> 5.0)

--- a/app/assets/stylesheets/orders/index.css
+++ b/app/assets/stylesheets/orders/index.css
@@ -1,0 +1,157 @@
+.transaction-contents {
+  width: 100vw;
+  background-color: #f5f5f5;
+  display: flex;
+  justify-content: center;
+}
+
+.transaction-main {
+  background-color: #FFF;
+  width: 70vw;
+  min-width: 450px;
+  padding: 10vh 10vw;
+}
+
+.transaction-title-text {
+  text-align: center;
+  border-bottom: 2px solid #f5f5f5;
+  font-weight: bold;
+  font-size: 22px;
+}
+
+/* 購入内容の表示 */
+.buy-item-info {
+  height: 150px;
+  border-bottom: 2px solid #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.buy-item-img {
+  margin-right: 20px;
+  height: 130px;
+  width: 250px;
+  object-fit: contain;
+}
+
+.buy-item-right-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.buy-item-text {
+  font-size: 20px;
+}
+
+.buy-item-price {
+  display: flex;
+  font-weight: bold;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.item-price-text {
+  font-size: 15px;
+  margin-right: 20px;
+}
+
+.item-price-sub-text {
+  font-size: 12px;
+}
+
+/* /購入内容の表示 */
+
+/* 支払額の表示 */
+.item-payment {
+  height: 120px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  border-bottom: 2px solid #f5f5f5;
+  font-weight: bold;
+}
+
+.item-payment-title {
+  font-size: 20px;
+}
+
+.item-payment-price {
+  font-size: 25px;
+}
+
+/* /支払額の表示 */
+
+/* カード情報の入力 */
+.credit-card-form {
+  border-bottom: 2px solid #f5f5f5;
+  margin-top: 15px;
+  padding-bottom: 30px;
+}
+
+.info-input-haedline {
+  text-align: center;
+  font-weight: bold;
+  font-size: 20px;
+}
+
+.available-card {
+  display: flex;
+  height: 35px;
+}
+
+.card-logo {
+  width: 40px;
+  margin: 5px 5px;
+}
+
+.input-expiration-date-wrap {
+  width: 100%;
+  display: flex;
+  text-align: center;
+  line-height: 55px;
+}
+
+.input-expiration-date {
+  width: 20%;
+  margin-top: 5px;
+  height: 48px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+  font-size: 16px;
+  resize: none;
+  line-height: 45px;
+  text-align: center;
+}
+
+/* /カード情報の入力 */
+
+/* 配送先の入力 */
+.shipping-address-form {
+  margin-top: 15px;
+}
+
+.form-any {
+  background: #ccc;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  padding: 2px 4px;
+}
+
+.buy-btn {
+  width: 50%;
+  margin: 0 auto;
+  margin-top: 50px;
+}
+
+.buy-red-btn {
+  width: 100%;
+  background: #ea352d;
+  border: 1px solid #ea352d;
+  color: #fff;
+  line-height: 48px;
+  font-size: 14px;
+  cursor: pointer;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -56,8 +56,8 @@ class ItemsController < ApplicationController
 
   def sold_item
     item = Item.find(params[:id])
-    if item.order.present?
-      redirect_to root_path
-    end
+    return unless item.order.present?
+
+    redirect_to root_path
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update]
+  before_action :sold_item, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -23,7 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    # 商品購入機能を実装後、購入済みの商品の編集ページへの遷移を制限する機能を追加する
     return if @item.user_id == current_user.id
 
     redirect_to root_path
@@ -52,5 +52,12 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def sold_item
+    item = Item.find(params[:id])
+    if item.order.present?
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,4 @@
+class OrdersController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,6 +2,7 @@ class OrdersController < ApplicationController
   def index
     @order_address = OrderAddress.new
     @item = Item.find(params[:item_id])
+    gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
   end
   
   def create

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,4 +1,6 @@
 class OrdersController < ApplicationController
   def index
+    @order_address = OrderAddress.new
+    @item = Item.find(params[:item_id])
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,8 +1,8 @@
 class OrdersController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_item
 
   def index
-    @item = Item.find(params[:item_id])
     if @item.user_id == current_user.id
       redirect_to root_path
     elsif @item.order.blank?
@@ -20,7 +20,6 @@ class OrdersController < ApplicationController
       @order_address.save
       redirect_to root_path
     else
-      @item = Item.find(params[:item_id])
       gon.public_key = ENV['PAYJP_PUBLIC_KEY']
       render 'index', status: :unprocessable_entity
     end
@@ -37,9 +36,13 @@ class OrdersController < ApplicationController
   def pay_item
     Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     Payjp::Charge.create(
-      amount: Item.find(params[:item_id]).price,
+      amount: set_item.price,
       card: params[:token],
       currency: 'jpy'
     )
+  end
+
+  def set_item
+    @item = Item.find(params[:item_id])
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -10,6 +10,7 @@ class OrdersController < ApplicationController
       @order_address.save
       redirect_to root_path
     else
+      @item = Item.find(params[:item_id])
       render :index, status: :unprocessable_entity
     end
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,16 +5,14 @@ class OrdersController < ApplicationController
     @item = Item.find(params[:item_id])
     if @item.user_id == current_user.id
       redirect_to root_path
+    elsif @item.order.blank?
+      @order_address = OrderAddress.new
+      gon.public_key = ENV['PAYJP_PUBLIC_KEY']
     else
-      if @item.order.blank?
-        @order_address = OrderAddress.new
-        gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
-      else
-        redirect_to root_path
-      end
+      redirect_to root_path
     end
   end
-  
+
   def create
     @order_address = OrderAddress.new(order_params)
     if @order_address.valid?
@@ -23,18 +21,21 @@ class OrdersController < ApplicationController
       redirect_to root_path
     else
       @item = Item.find(params[:item_id])
-      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+      gon.public_key = ENV['PAYJP_PUBLIC_KEY']
       render 'index', status: :unprocessable_entity
     end
   end
 
   private
+
   def order_params
-    params.require(:order_address).permit(:postal_code, :prefecture_id, :city, :address, :building_name, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+    params.require(:order_address).permit(:postal_code, :prefecture_id, :city, :address, :building_name, :phone_number).merge(
+      user_id: current_user.id, item_id: params[:item_id], token: params[:token]
+    )
   end
 
   def pay_item
-    Payjp::api_key = ENV["PAYJP_SECRET_KEY"]
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     Payjp::Charge.create(
       amount: Item.find(params[:item_id]).price,
       card: params[:token],

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,4 +1,6 @@
 class OrdersController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     @item = Item.find(params[:item_id])
     if @item.user_id == current_user.id

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,5 +5,17 @@ class OrdersController < ApplicationController
   end
   
   def create
+    @order_address = OrderAddress.new(order_params)
+    if @order_address.valid?
+      @order_address.save
+      redirect_to root_path
+    else
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def order_params
+    params.require(:order_address).permit(:postal_code, :prefecture_id, :city, :address, :building_name, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id])
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -6,8 +6,12 @@ class OrdersController < ApplicationController
     if @item.user_id == current_user.id
       redirect_to root_path
     else
-      @order_address = OrderAddress.new
-      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+      if @item.order.blank?
+        @order_address = OrderAddress.new
+        gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+      else
+        redirect_to root_path
+      end
     end
   end
   

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,4 +3,7 @@ class OrdersController < ApplicationController
     @order_address = OrderAddress.new
     @item = Item.find(params[:item_id])
   end
+  
+  def create
+  end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,8 +1,12 @@
 class OrdersController < ApplicationController
   def index
-    @order_address = OrderAddress.new
     @item = Item.find(params[:item_id])
-    gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+    if @item.user_id == current_user.id
+      redirect_to root_path
+    else
+      @order_address = OrderAddress.new
+      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+    end
   end
   
   def create

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "item_price"
+import "card"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,28 @@
+window.addEventListener("DOMContentLoaded", () => {
+    const pagePath = location.pathname;
+  if (pagePath.indexOf('orders') !== -1) {
+    const publicKey = gon.public_key;
+    window.payjp = Payjp(publicKey);
+    const elements = payjp.elements();
+    const numberElement = elements.create('cardNumber');
+    const expiryElement = elements.create('cardExpiry');
+    const cvcElement = elements.create('cardCvc');
+  
+    numberElement.mount('#number-form');
+    expiryElement.mount('#expiry-form');
+    cvcElement.mount('#cvc-form');
+  
+    const form = document.getElementById('charge-form')
+    form.addEventListener("submit", (e) => {
+      console.log(numberElement)
+      payjp.createToken(numberElement).then(function (response) {
+        if (response.error) {
+        } else {
+          const token = response.id;
+          console.log(token);
+        }
+      });
+      e.preventDefault();
+    });
+  }
+});

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -14,13 +14,18 @@ window.addEventListener("DOMContentLoaded", () => {
   
     const form = document.getElementById('charge-form')
     form.addEventListener("submit", (e) => {
-      console.log(numberElement)
       payjp.createToken(numberElement).then(function (response) {
         if (response.error) {
         } else {
           const token = response.id;
-          console.log(token);
+          const renderDom = document.getElementById('charge-form');
+          const tokenObj = `<input value=${token} name='token' type="hidden">`;
+          renderDom.insertAdjacentHTML("beforeend", tokenObj);
         }
+        numberElement.clear();
+        expiryElement.clear();
+        cvcElement.clear();
+        form.submit();
       });
       e.preventDefault();
     });

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,12 @@
+class Address < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :prefecture
+
+  belongs_to :order
+  
+  validates :postal_code, presence: true, format: { with: /\A\d{3}[-]\d{4}\z/ }
+  validates :prefecture_id, presence: true, numericality: { greater_han: 1 }
+  validates :city, presence: true
+  validates :address, presence: true
+  validates :phone_number, presence: true, format: { with: /\A\d{10,11}\z/ }
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -3,10 +3,4 @@ class Address < ApplicationRecord
   belongs_to :prefecture
 
   belongs_to :order
-  
-  validates :postal_code, presence: true, format: { with: /\A\d{3}[-]\d{4}\z/ }
-  validates :prefecture_id, presence: true, numericality: { greater_han: 1 }
-  validates :city, presence: true
-  validates :address, presence: true
-  validates :phone_number, presence: true, format: { with: /\A\d{10,11}\z/ }
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,7 @@ class Item < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image, dependent: :destroy
+  has_one :order
 
   validates :image,       presence: true
   validates :name,        presence: true, length: { maximum: 40 }

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :address
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -5,9 +5,13 @@ class OrderAddress
   validates :user_id, presence: true
   validates :item_id, presence: true
   validates :postal_code, presence: true, format: { with: /\A\d{3}[-]\d{4}\z/ }
-  validates :prefecture_id, presence: true, numericality: { greater_han: 1 }
+  validates :prefecture_id, presence: true, numericality: { greater_than: 1 }
   validates :city, presence: true
   validates :address, presence: true
   validates :phone_number, presence: true, format: { with: /\A\d{10,11}\z/ }
 
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, address: address, building_name: building_name, phone_number: phone_number, order_id: order.id)
+  end
 end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -4,7 +4,7 @@ class OrderAddress
 
   validates :user_id, presence: true
   validates :item_id, presence: true
-  validates :postal_code, presence: true, format: { with: /\A\d{3}[-]\d{4}\z/ }
+  validates :postal_code, presence: true, format: { with: /\A\d{3}-\d{4}\z/ }
   validates :prefecture_id, presence: true, numericality: { greater_than: 1 }
   validates :city, presence: true
   validates :address, presence: true
@@ -12,7 +12,8 @@ class OrderAddress
   validates :token, presence: true
 
   def save
-    order = Order.create(user_id: user_id, item_id: item_id)
-    Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, address: address, building_name: building_name, phone_number: phone_number, order_id: order.id)
+    order = Order.create(user_id:, item_id:)
+    Address.create(postal_code:, prefecture_id:, city:, address:,
+                   building_name:, phone_number:, order_id: order.id)
   end
 end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,13 @@
+class OrderAddress
+  include ActiveModel::Model
+  attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :address, :building_name, :phone_number
+
+  validates :user_id, presence: true
+  validates :item_id, presence: true
+  validates :postal_code, presence: true, format: { with: /\A\d{3}[-]\d{4}\z/ }
+  validates :prefecture_id, presence: true, numericality: { greater_han: 1 }
+  validates :city, presence: true
+  validates :address, presence: true
+  validates :phone_number, presence: true, format: { with: /\A\d{10,11}\z/ }
+
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -2,14 +2,16 @@ class OrderAddress
   include ActiveModel::Model
   attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :address, :building_name, :phone_number, :token
 
-  validates :user_id, presence: true
-  validates :item_id, presence: true
-  validates :postal_code, presence: true, format: { with: /\A\d{3}-\d{4}\z/ }
-  validates :prefecture_id, presence: true, numericality: { greater_than: 1 }
-  validates :city, presence: true
-  validates :address, presence: true
-  validates :phone_number, presence: true, format: { with: /\A\d{10,11}\z/ }
-  validates :token, presence: true
+  with_options presence: true do
+    validates :user_id
+    validates :item_id
+    validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/ }
+    validates :prefecture_id, numericality: { greater_than: 1 }
+    validates :city
+    validates :address
+    validates :phone_number, format: { with: /\A\d{10,11}\z/ }
+    validates :token
+  end
 
   def save
     order = Order.create(user_id:, item_id:)

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,6 +1,6 @@
 class OrderAddress
   include ActiveModel::Model
-  attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :address, :building_name, :phone_number
+  attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :address, :building_name, :phone_number, :token
 
   validates :user_id, presence: true
   validates :item_id, presence: true
@@ -9,6 +9,7 @@ class OrderAddress
   validates :city, presence: true
   validates :address, presence: true
   validates :phone_number, presence: true, format: { with: /\A\d{10,11}\z/ }
+  validates :token, presence: true
 
   def save
     order = Order.create(user_id: user_id, item_id: item_id)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,12 +133,11 @@
             <%= link_to item_path(item) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
-
-              <%# 購入機能実装後にSoldOutマークを実装する %>
-              <%# <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div> %>
-
+              <% if item.order.present? %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+              <% end %>
             </div>
             <div class='item-info'>
               <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
         <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
       <%# 購入機能実装後、商品が売れた後は購入画面へのリンクを表示しないよう修正する %>
-        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%= link_to "購入画面に進む", item_orders_path(@item) ,class:"item-red-btn"%>
       <% end %>
     <% end %>
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
         <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
       <%# 購入機能実装後、商品が売れた後は購入画面へのリンクを表示しないよう修正する %>
-        <%= link_to "購入画面に進む", item_orders_path(@item) ,class:"item-red-btn"%>
+        <%= link_to "購入画面に進む", item_orders_path(@item) ,class:"item-red-btn", 'data-turbo': false %>
       <% end %>
     <% end %>
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,10 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 購入機能実装後にsold out表示を実装する %>
-      <%# <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div> %>
+      <% if @item.order.present? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -21,13 +22,12 @@
         <%= @item.shipping_bear.name %>
       </span>
     </div>
-    <% if user_signed_in? %>
+    <% if user_signed_in? && @item.order.blank? %>
       <% if @item.user_id == current_user.id %>
         <%= link_to "商品の編集", edit_item_path(@item) , method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
-      <%# 購入機能実装後、商品が売れた後は購入画面へのリンクを表示しないよう修正する %>
         <%= link_to "購入画面に進む", item_orders_path(@item) ,class:"item-red-btn", 'data-turbo': false %>
       <% end %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
 </head>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,127 @@
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= "商品名" %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= '999,999,999' %></p>
+          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= "販売価格" %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+
+    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%# カード情報の入力 %>
+    <div class='credit-card-form'>
+      <h1 class='info-input-haedline'>
+        クレジットカード情報入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">カード情報</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="number-form" class="input-default"></div>
+        <div class='available-card'>
+          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">有効期限</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div class='input-expiration-date-wrap'>
+          <div id="expiry-form" class="input-default"></div>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">セキュリティコード</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="cvc-form" class="input-default"></div>
+      </div>
+    </div>
+    <%# /カード情報の入力 %>
+    
+    <%# 配送先の入力 %>
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+      </div>
+    </div>
+    <%# /配送先の入力 %>
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/second-header"%>
-
+<%= include_gon %>
 <div class='transaction-contents'>
   <div class='transaction-main'>
   

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -2,6 +2,7 @@
 
 <div class='transaction-contents'>
   <div class='transaction-main'>
+  
     <h1 class='transaction-title-text'>
       購入内容の確認
     </h1>
@@ -30,7 +31,6 @@
       </p>
     </div>
     <%# /支払額の表示 %>
-
     <%= form_with model: @order_address, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
@@ -74,6 +74,7 @@
       <h1 class='info-input-haedline'>
         配送先入力
       </h1>
+      <%= render 'shared/error_messages', model: f.object %>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">郵便番号</label>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @item.image, class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_bear.name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +26,12 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @item.price %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @order_address, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -79,42 +79,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :postal_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :address, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building_name, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -32,6 +32,7 @@
     </div>
     <%# /支払額の表示 %>
     <%= form_with model: @order_address, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -74,7 +75,6 @@
       <h1 class='info-input-haedline'>
         配送先入力
       </h1>
-      <%= render 'shared/error_messages', model: f.object %>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">郵便番号</label>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "item_price", to: "item_price.js"
+pin "card", to:"card.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   root "items#index"
 
-  resources :items
-  resources :orders, only: :index
+  resources :items do
+    resources :orders, only: :index
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   root "items#index"
 
   resources :items
+  resources :orders, only: :index
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   root "items#index"
 
   resources :items do
-    resources :orders, only: :index
+    resources :orders, only: [:index, :create]
   end
 end

--- a/db/migrate/20230814131507_create_orders.rb
+++ b/db/migrate/20230814131507_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references  :user,  null: false,  foreign_key: true
+      t.references  :item,  null: false,  foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230814132144_create_addresses.rb
+++ b/db/migrate/20230814132144_create_addresses.rb
@@ -1,13 +1,13 @@
 class CreateAddresses < ActiveRecord::Migration[7.0]
   def change
     create_table :addresses do |t|
-      t.string  :postal_code,   null: false
-      t.integer :prefecture_id, null: false
-      t.string  :city ,         null: false
-      t.string  :address,       null: false
-      t.string  :building_name
-      t.string  :phone_number,  null: false
-      t.string  :order,         null: false,  foreign_key: true
+      t.string      :postal_code,   null: false
+      t.integer     :prefecture_id, null: false
+      t.string      :city ,         null: false
+      t.string      :address,       null: false
+      t.string      :building_name
+      t.string      :phone_number,  null: false
+      t.references  :order,         null: false,  foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20230814132144_create_addresses.rb
+++ b/db/migrate/20230814132144_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :addresses do |t|
+      t.string  :postal_code,   null: false
+      t.integer :prefecture_id, null: false
+      t.string  :city ,         null: false
+      t.string  :address,       null: false
+      t.string  :building_name
+      t.string  :phone_number,  null: false
+      t.string  :order,         null: false,  foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,9 +46,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_132144) do
     t.string "address", null: false
     t.string "building_name"
     t.string "phone_number", null: false
-    t.string "order", null: false
+    t.bigint "order_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_addresses_on_order_id"
   end
 
   create_table "items", charset: "utf8", force: :cascade do |t|
@@ -95,6 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_132144) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "orders"
   add_foreign_key "items", "users"
   add_foreign_key "orders", "items"
   add_foreign_key "orders", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_09_091433) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_14_132144) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,6 +39,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_091433) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "addresses", charset: "utf8", force: :cascade do |t|
+    t.string "postal_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "address", null: false
+    t.string "building_name"
+    t.string "phone_number", null: false
+    t.string "order", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "items", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "description", null: false
@@ -52,6 +64,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_091433) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|
@@ -75,4 +96,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_091433) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :address do
-    
   end
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :order_address do
+    postal_code   { "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 4)}" }
+    prefecture_id { rand(2..48) }
+    city          { Gimei.address.prefecture.kanji }
+    address       { Gimei.address.town.kanji }
+    building_name { Faker::Address.building_number }
+    phone_number  { Faker::Number.number(digits: 11) }
+    token         { "tok_#{Faker::Alphanumeric.alpha(number: 10)}#{Faker::Number.number(digits: 17)}" }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :order do
-    
   end
 end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe OrderAddress, type: :model do
+  before do
+    user = FactoryBot.create(:user)
+    item = FactoryBot.create(:item)
+    sleep 0.1
+    @order_address = FactoryBot.build(:order_address, user_id: user.id, item_id: item.id)
+  end
+  describe '商品購入機能' do
+    context '商品が購入できる場合' do
+      it 'カード情報及び配送先が全て記載されていると購入できる' do
+        expect(@order_address).to be_valid
+      end
+      it '電話番号が10ケタで入力されても購入できる' do
+        @order_address.phone_number = 1_234_567_890
+        expect(@order_address).to be_valid
+      end
+      it '建物名の項目のみ空欄でも購入できる' do
+        @order_address.building_name = ''
+        expect(@order_address).to be_valid
+      end
+    end
+    context '商品を購入できない場合' do
+      it 'カード情報（＝トークン）が無いと購入できない' do
+        @order_address.token = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Token can't be blank")
+      end
+      it '郵便番号が無いと購入できない' do
+        @order_address.postal_code = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Postal code can't be blank")
+      end
+      it '郵便番号の前半が2ケタ以下だと購入できない' do
+        @order_address.postal_code = '12-3456'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Postal code is invalid')
+      end
+      it '郵便番号の前半が4ケタ以上だと購入できない' do
+        @order_address.postal_code = '1234-1234'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Postal code is invalid')
+      end
+      it '郵便番号にハイフンが無いと購入できない' do
+        @order_address.postal_code = '1234567'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Postal code is invalid')
+      end
+      it '郵便番号の後半が3ケタ以下だと購入できない' do
+        @order_address.postal_code = '123-456'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Postal code is invalid')
+      end
+      it '郵便番号の後半が5ケタ以上だと購入できない' do
+        @order_address.postal_code = '123-45678'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Postal code is invalid')
+      end
+      it '郵便番号が全角で記入されていると購入できない' do
+        @order_address.postal_code = '１２３－４５６７'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Postal code is invalid')
+      end
+      it '郵便番号に半角数字以外の半角文字を使うと購入できない' do
+        @order_address.postal_code = 'a12-@345'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Postal code is invalid')
+      end
+      it '都道府県が選択されていないと購入できない' do
+        @order_address.prefecture_id = 1
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Prefecture must be greater than 1')
+      end
+      it '市区町村名が記入されていないと購入できない' do
+        @order_address.city = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("City can't be blank")
+      end
+      it '番地が記入されていないと購入できない' do
+        @order_address.address = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Address can't be blank")
+      end
+      it '電話番号が記入されていないと購入できない' do
+        @order_address.phone_number = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone number can't be blank")
+      end
+      it '電話番号が9ケタ以下だと購入できない' do
+        @order_address.phone_number = 123_456_789
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Phone number is invalid')
+      end
+      it '電話番号が12ケタ以上だと購入できない' do
+        @order_address.phone_number = '090123456789'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Phone number is invalid')
+      end
+      it '電話番号に半角数字以外が含まれていると購入できない' do
+        @order_address.phone_number = '0a012345678'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Phone number is invalid')
+      end
+      it '電話番号が全角で記入されていると購入できない' do
+        @order_address.phone_number = '０９０１２３４５６７８'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Phone number is invalid')
+      end
+      it 'ユーザーの情報が紐づいていないと購入できない' do
+        @order_address.user_id = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("User can't be blank")
+      end
+      it '商品の情報が紐づいていないと購入できない' do
+        @order_address.item_id = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Item can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe OrderAddress, type: :model do
   before do
     user = FactoryBot.create(:user)
     item = FactoryBot.create(:item)
-    sleep 0.1
+    sleep 0.01
     @order_address = FactoryBot.build(:order_address, user_id: user.id, item_id: item.id)
   end
   describe '商品購入機能' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Orders", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Orders', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end


### PR DESCRIPTION
# What
* Orderモデル、Addressモデル、OrderAddressモデルの作成
* ordersコントローラーを作成(index、createアクションを設定）
* 関連するルーティングを設定
* orderテーブルとaddressテーブルへの保存機能を実装
* Pay.jpのAPIを利用したクレジット決済機能を実装
* 購入ページへの遷移の制限を実装
* OrderAddressモデルの単体テストコードを記述

# Why
商品購入機能を実装するため

## 挙動確認用動画
* 商品が正常に購入できる (https://gyazo.com/f747c74d119390496bf672eb7c2646fc)
* 購入時のフォーム入力に不備がある場合 (https://gyazo.com/96789816678dc7b4d1e17e574fd5013c)
* 他ユーザーの売却済み商品の購入ページへは遷移できない (https://gyazo.com/24a1ece45156c30829aa703793c8629b)
* 自身の商品の購入ページへは遷移できない (https://gyazo.com/00d12c36a2adb6f9e43bfd6140fa1e7f)
* 未ログインユーザーは購入ページへ遷移できない (https://gyazo.com/598d12ccf0d3a525da2a71e729d1f008)
* 商品一覧ページで売却済み商品にsold outの表示がある (https://gyazo.com/f747c74d119390496bf672eb7c2646fc)
* 商品詳細ページで売却済み商品にsold outの表示がある (https://gyazo.com/eeed4acddee1e22219f0fd1b44e3c644)
* 売却済み商品の詳細ページでは各種ボタンが表示されない (https://gyazo.com/eeed4acddee1e22219f0fd1b44e3c644)
* 自身の売却済み商品の編集ページへは遷移できない (https://gyazo.com/b7f508bbbf5b3a407aca1d86be1bb15f)
* モデル単体テストが正常に通過する (https://gyazo.com/a812ca667a8a1dc0905f1a6a5e01ea6d)